### PR TITLE
ci: validate jsonc file, fixes #4

### DIFF
--- a/.github/workflows/validate-jsonc.yaml
+++ b/.github/workflows/validate-jsonc.yaml
@@ -3,7 +3,7 @@ name: Validate JSONC
 on: [push, pull_request]
 
 jobs:
-  validate:
+  validate-jsonc:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validate-jsonc.yaml
+++ b/.github/workflows/validate-jsonc.yaml
@@ -12,8 +12,6 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        with:
-          node-version: '14'
 
       - name: Install dependencies
         run: npm install jsonc-parser
@@ -22,5 +20,5 @@ jobs:
         run: |
           for file in *.jsonc; do
             echo "Validating $file"
-            npx jsonc-parser parse $file
+            node validate-jsonc.js $file
           done

--- a/.github/workflows/validate-jsonc.yaml
+++ b/.github/workflows/validate-jsonc.yaml
@@ -1,0 +1,26 @@
+name: Validate JSONC
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install jsonc-parser
+
+      - name: Validate JSONC files
+        run: |
+          for file in *.jsonc; do
+            echo "Validating $file"
+            npx jsonc-parser parse $file
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/package-lock.json
+/package.json

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -93,7 +93,7 @@
                 },
 				{
                     "message": "MacStadium supports DDEV with an M1 Mac Mini that runs macOS tests"
-                }
+                },
 			]
 		}
 	}

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -17,7 +17,7 @@
 		// Ticker messages are are shown once in an interval and are rotated
 		// once a message was shown.
 		"ticker": {
-			"interval": 20,
+			"interval": 20, and 99
 			"messages": [
 			    {
                     "message": "Join the DDEV Discord to support others and get support: https://discord.gg/hCZFfAMc5k"
@@ -93,7 +93,7 @@
                 },
 				{
                     "message": "MacStadium supports DDEV with an M1 Mac Mini that runs macOS tests"
-                },
+                }
 			]
 		}
 	}

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -17,7 +17,7 @@
 		// Ticker messages are are shown once in an interval and are rotated
 		// once a message was shown.
 		"ticker": {
-			"interval": 20, and 99
+			"interval": 20,
 			"messages": [
 			    {
                     "message": "Join the DDEV Discord to support others and get support: https://discord.gg/hCZFfAMc5k"

--- a/validate-jsonc.js
+++ b/validate-jsonc.js
@@ -1,0 +1,51 @@
+// Uses https://www.npmjs.com/package/jsonc-parser
+// Generated in a conversation with ChatGPT, https://chat.openai.com/share/9ed4dc4d-2442-4693-9f32-131a5f12ab9a
+// node validate-jsonc.js remote-config.jsonc
+const fs = require('fs');
+const { parseTree, ParseErrorCode } = require('jsonc-parser');
+
+const getLineAndCharacter = (content, offset) => {
+    const beforeError = content.slice(0, offset);
+    const line = beforeError.split('\n').length;
+    const character = beforeError.split('\n').pop().length + 1;
+    return { line, character };
+};
+
+const filePath = process.argv[2];
+const fileContent = fs.readFileSync(filePath, 'utf-8');
+
+const errorMessages = {
+    [ParseErrorCode.CloseBraceExpected]: "Expected close brace }",
+    [ParseErrorCode.CloseBracketExpected]: "Expected close bracket ]",
+    [ParseErrorCode.ColonExpected]: "Expected colon :",
+    [ParseErrorCode.CommaExpected]: "Expected comma ,",
+    [ParseErrorCode.EndOfFileExpected]: "Expected end of file",
+    [ParseErrorCode.InvalidCharacter]: "Invalid character",
+    [ParseErrorCode.InvalidCommentToken]: "Invalid comment token",
+    [ParseErrorCode.InvalidNumberFormat]: "Invalid number format",
+    [ParseErrorCode.InvalidSymbol]: "Invalid symbol",
+    [ParseErrorCode.OpenBraceExpected]: "Expected open brace {",
+    [ParseErrorCode.OpenBracketExpected]: "Expected open bracket [",
+    [ParseErrorCode.PropertyNameExpected]: "Expected property name",
+    [ParseErrorCode.ValueExpected]: "Expected value",
+};
+
+try {
+    const errors = [];
+    parseTree(fileContent, errors);
+
+    if (errors.length > 0) {
+        console.error(`Error in ${filePath}:`);
+        errors.forEach(error => {
+            const { line, character } = getLineAndCharacter(fileContent, error.offset);
+            const message = errorMessages[error.error] || "Unknown error";
+            console.error(`- ${message} at offset ${error.offset} (line: ${line}, character: ${character})`);
+        });
+        process.exit(1);
+    } else {
+        console.log(`${filePath} is valid JSONC.`);
+    }
+} catch (error) {
+    console.error(`Unexpected error in ${filePath}: ${error.message}`);
+    process.exit(1);
+}


### PR DESCRIPTION
## The Issue

We need some validation of our config file so we can't break everybody with a PR to update messages

## How This PR Solves The Issue

Do basic validation

## Manual Testing Instructions

I just tried a number of bad edits and pushed.

Before that I was doing `node validate-jsonc.js remote-config.jsonc` after making changes to the remote-config file

