### PR TITLE
add warning about key expiration, first use of version constraint

### DIFF
--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -20,7 +20,7 @@
       "interval": 20,
       "infos": [
         {
-          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
+          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration as of 16 Feb 2024. This does not affect DDEV v1.22.7, so upgrade, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
           "versions": "<=v1.22.6"
         }
       ],

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -21,8 +21,8 @@
       "infos": [
         {
           "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
-          "title": "this is a test",
-//          "versions": "<v1.22.7"
+          "versions": "<=v1.22.6",
+          "title": "this is a test"
         }
       ],
       "warnings": []

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -20,7 +20,8 @@
       "interval": 20,
       "infos": [
         {
-          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795"
+          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
+          "title": "this is a test",
 //          "versions": "<v1.22.7"
         }
       ],

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -20,8 +20,8 @@
       "interval": 20,
       "infos": [
         {
-          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
-          "versions": "<v1.22.7"
+          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795"
+//          "versions": "<v1.22.7"
         }
       ],
       "warnings": []

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -21,7 +21,7 @@
       "infos": [
         {
           "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
-          "version": "<v1.22.7"
+          "versions": "<v1.22.7"
         }
       ],
       "warnings": []

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -18,14 +18,12 @@
     // once a message was shown.
     "notifications": {
       "interval": 20,
-      "infos": {
-        "messages": [
-          {
-            "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
-            "version": "<v1.22.7"
-          }
-        ]
-      },
+      "infos": [
+        {
+          "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
+          "version": "<v1.22.7"
+        }
+      ],
       "warnings": []
     },
     "ticker": {

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -21,8 +21,7 @@
       "infos": [
         {
           "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
-          "versions": "<=v1.22.6",
-          "title": "this is a test"
+          "versions": "<=v1.22.6"
         }
       ],
       "warnings": []

--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -18,7 +18,14 @@
     // once a message was shown.
     "notifications": {
       "interval": 20,
-      "infos": [],
+      "infos": {
+        "messages": [
+          {
+            "message": "The upstream deb.sury.org package key was unfortunately allowed to come near expiration. This does not affect DDEV v1.22.7, but if you see warnings or errors in earlier versions during `ddev start` the easy fix is in https://github.com/ddev/ddev/issues/5795",
+            "version": "<v1.22.7"
+          }
+        ]
+      },
       "warnings": []
     },
     "ticker": {


### PR DESCRIPTION
## The Issue

deb.sury.org old key will be expiring tomorrow, provide a notice of this

This is the first experimental use of "info", and with a version constraint.

