### PR TITLE
update xhgui URL

### DIFF
--- a/remote-config.jsonc
+++ b/remote-config.jsonc
@@ -231,7 +231,7 @@
           "message": "Are you using DDEV in Continuous Integration (CI) or any kind of automated testing? If so, please turn off instrumentation, `ddev config global --instrumentation-opt-in=false` or `export DDEV_NO_INSTRUMENTATION=true`"
         },
         {
-          "message": "Want to profile your code in an improved more beautiful manner with Xhprof? Try out @tyler36's ddev/ddev-xhgui, https://github.com/tyler36/ddev-xhgui"
+          "message": "Want to profile your code in an improved more beautiful manner with Xhprof? Try out @tyler36's https://github.com/ddev/ddev-xhgui"
         },
         {
           "message": "DDEV v1.23.0 introduces Drupal 11 support and the `drupal` project type, so we don't have to do a new project type for every release. https://github.com/ddev/ddev/releases/tag/v1.23.0"


### PR DESCRIPTION
## The Issue

Recently `tyler36/ddev-xhgui` became official.
Github automatically redirects the URL but its better to show its "true" location.

## How This PR Solves The Issue
Update URL

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

